### PR TITLE
test(device_config): Remove integration test

### DIFF
--- a/attendance_sync/attendance_sync/doctype/device_configuration/test_device_configuration.py
+++ b/attendance_sync/attendance_sync/doctype/device_configuration/test_device_configuration.py
@@ -2,22 +2,13 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import  UnitTestCase
 
 
 class TestDeviceConfiguration(UnitTestCase):
 	"""
 	Unit tests for DeviceConfiguration.
 	Use this class for testing individual functions and methods.
-	"""
-
-	pass
-
-
-class TestDeviceConfigurationExtra(IntegrationTestCase):
-	"""
-	Integration tests for DeviceConfiguration.
-	Use this class for testing interactions between multiple components.
 	"""
 
 	pass


### PR DESCRIPTION
Refactors the device configuration tests by removing an unnecessary integration test class.

- Removes  class.
- Simplifies test setup.

This reduces test complexity.